### PR TITLE
Fix product card image hover preview functionality

### DIFF
--- a/client/components/ContactModal.tsx
+++ b/client/components/ContactModal.tsx
@@ -57,8 +57,15 @@ export default function ContactModal({
             />
           </label>
 
-          {/* hidden product field */}
-          <input type="hidden" name="product" value={productName ?? ""} />
+          <label className="grid gap-2 text-sm">
+            <span>Product of Interest</span>
+            <input
+              name="product"
+              readOnly
+              value={productName ?? ""}
+              className="h-11 rounded-lg border border-slate-300 bg-slate-100 px-3 text-slate-900 outline-none"
+            />
+          </label>
 
           <div className="flex items-center justify-between">
             <p className="text-xs text-slate-500">By submitting, you agree to the processing of personal data.</p>

--- a/client/components/ContactModal.tsx
+++ b/client/components/ContactModal.tsx
@@ -67,12 +67,10 @@ export default function ContactModal({
             />
           </label>
 
-          <div className="flex items-center justify-between">
-            <p className="text-xs text-slate-500">By submitting, you agree to the processing of personal data.</p>
-            <button className="ml-4 inline-flex items-center justify-center rounded-lg bg-[hsl(var(--brand-end))] px-4 py-2.5 text-sm font-semibold text-white shadow transition hover:shadow-md">
-              Send request
-            </button>
-          </div>
+          <button className="w-full inline-flex items-center justify-center rounded-lg bg-[hsl(var(--brand-end))] px-4 py-2.5 text-sm font-semibold text-white shadow transition hover:shadow-md">
+            Send request
+          </button>
+          <p className="mt-2 text-xs text-slate-500">By submitting, you agree to the processing of personal data.</p>
         </form>
       </DialogContent>
     </Dialog>

--- a/client/components/ContactModal.tsx
+++ b/client/components/ContactModal.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+
+export default function ContactModal({
+  open,
+  productName,
+  onOpenChange,
+}: {
+  open: boolean;
+  productName?: string | null;
+  onOpenChange: (v: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Contact Us</DialogTitle>
+          <DialogDescription>
+            Leave your details and our team will prepare a tailored quote for your facility.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const form = new FormData(e.currentTarget as HTMLFormElement);
+            if (productName) form.set("product", productName);
+            console.log(Object.fromEntries(form.entries()));
+            alert("Thank you! We will contact you shortly.");
+            onOpenChange(false);
+          }}
+          className="grid gap-4"
+        >
+          <label className="grid gap-2 text-sm">
+            <span>Name</span>
+            <input
+              name="name"
+              required
+              className="h-11 rounded-lg border border-slate-300 bg-white px-3 text-slate-900 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm">
+            <span>Phone or email</span>
+            <input
+              name="contact"
+              required
+              className="h-11 rounded-lg border border-slate-300 bg-white px-3 text-slate-900 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm">
+            <span>Message</span>
+            <textarea
+              name="message"
+              rows={4}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+            />
+          </label>
+
+          {/* hidden product field */}
+          <input type="hidden" name="product" value={productName ?? ""} />
+
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-slate-500">By submitting, you agree to the processing of personal data.</p>
+            <button className="ml-4 inline-flex items-center justify-center rounded-lg bg-[hsl(var(--brand-end))] px-4 py-2.5 text-sm font-semibold text-white shadow transition hover:shadow-md">
+              Send request
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/components/ContactModal.tsx
+++ b/client/components/ContactModal.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 
 export default function ContactModal({
   open,
@@ -16,7 +22,8 @@ export default function ContactModal({
         <DialogHeader>
           <DialogTitle>Contact Us</DialogTitle>
           <DialogDescription>
-            Leave your details and our team will prepare a tailored quote for your facility.
+            Leave your details and our team will prepare a tailored quote for
+            your facility.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -70,7 +77,9 @@ export default function ContactModal({
           <button className="w-full inline-flex items-center justify-center rounded-lg bg-[hsl(var(--brand-end))] px-4 py-2.5 text-sm font-semibold text-white shadow transition hover:shadow-md">
             Send request
           </button>
-          <p className="mt-2 text-xs text-slate-500">By submitting, you agree to the processing of personal data.</p>
+          <p className="mt-2 text-xs text-slate-500">
+            By submitting, you agree to the processing of personal data.
+          </p>
         </form>
       </DialogContent>
     </Dialog>

--- a/client/components/ContactModal.tsx
+++ b/client/components/ContactModal.tsx
@@ -49,21 +49,21 @@ export default function ContactModal({
           </label>
 
           <label className="grid gap-2 text-sm">
-            <span>Message</span>
-            <textarea
-              name="message"
-              rows={4}
-              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
-            />
-          </label>
-
-          <label className="grid gap-2 text-sm">
             <span>Product of Interest</span>
             <input
               name="product"
               readOnly
               value={productName ?? ""}
               className="h-11 rounded-lg border border-slate-300 bg-slate-100 px-3 text-slate-900 outline-none"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm">
+            <span>Message</span>
+            <textarea
+              name="message"
+              rows={4}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
             />
           </label>
 

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -41,7 +41,9 @@ export default function Header() {
   const [openSubmenuKey, setOpenSubmenuKey] = useState<string | null>(null);
   const [desktopOpenKey, setDesktopOpenKey] = useState<string | null>(null);
   const [scrolled, setScrolled] = useState(false);
-  const isProductDetail = location.pathname.startsWith("/products/") && location.pathname !== "/products";
+  const isProductDetail =
+    location.pathname.startsWith("/products/") &&
+    location.pathname !== "/products";
 
   useEffect(() => {
     const anchor = document.querySelector<HTMLElement>("[data-header-anchor]");
@@ -109,7 +111,9 @@ export default function Header() {
               <span
                 className={cn(
                   "font-semibold tracking-wide transition-colors",
-                  scrolled || open || isProductDetail ? "text-slate-900" : "text-white",
+                  scrolled || open || isProductDetail
+                    ? "text-slate-900"
+                    : "text-white",
                 )}
               >
                 Esco Biosafety Institute
@@ -168,8 +172,8 @@ export default function Header() {
                     className={cn(
                       "transition-colors",
                       scrolled || isProductDetail
-                          ? "text-slate-700 hover:text-slate-900"
-                          : "text-white/85 hover:text-white",
+                        ? "text-slate-700 hover:text-slate-900"
+                        : "text-white/85 hover:text-white",
                     )}
                   >
                     {item.label}
@@ -274,8 +278,8 @@ export default function Header() {
                     className={cn(
                       "block w-full rounded-full px-5 py-2.5 text-center text-base font-semibold shadow transition hover:shadow-md",
                       scrolled || open || isProductDetail
-                    ? "bg-[hsl(var(--brand-end))] text-white"
-                    : "bg-white text-slate-900",
+                        ? "bg-[hsl(var(--brand-end))] text-white"
+                        : "bg-white text-slate-900",
                     )}
                     onClick={() => setOpen(false)}
                   >

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -41,6 +41,7 @@ export default function Header() {
   const [openSubmenuKey, setOpenSubmenuKey] = useState<string | null>(null);
   const [desktopOpenKey, setDesktopOpenKey] = useState<string | null>(null);
   const [scrolled, setScrolled] = useState(false);
+  const isProductDetail = location.pathname.startsWith("/products/") && location.pathname !== "/products";
 
   useEffect(() => {
     const anchor = document.querySelector<HTMLElement>("[data-header-anchor]");
@@ -94,7 +95,7 @@ export default function Header() {
       <header
         className={cn(
           "sticky top-0 z-[9999] transition-colors duration-300",
-          scrolled || open
+          scrolled || open || isProductDetail
             ? "bg-white border-b border-white/60 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white"
             : "bg-transparent border-b border-transparent text-white",
         )}
@@ -108,7 +109,7 @@ export default function Header() {
               <span
                 className={cn(
                   "font-semibold tracking-wide transition-colors",
-                  scrolled || open ? "text-slate-900" : "text-white",
+                  scrolled || open || isProductDetail ? "text-slate-900" : "text-white",
                 )}
               >
                 Esco Biosafety Institute
@@ -127,7 +128,7 @@ export default function Header() {
                     <button
                       className={cn(
                         "inline-flex items-center gap-1 transition-colors",
-                        scrolled
+                        scrolled || isProductDetail
                           ? "text-slate-700 hover:text-slate-900"
                           : "text-white/85 hover:text-white",
                       )}
@@ -166,9 +167,9 @@ export default function Header() {
                     to={item.to!}
                     className={cn(
                       "transition-colors",
-                      scrolled
-                        ? "text-slate-700 hover:text-slate-900"
-                        : "text-white/85 hover:text-white",
+                      scrolled || isProductDetail
+                          ? "text-slate-700 hover:text-slate-900"
+                          : "text-white/85 hover:text-white",
                     )}
                   >
                     {item.label}
@@ -179,7 +180,7 @@ export default function Header() {
                 to="/contact"
                 className={cn(
                   "ml-2 inline-flex items-center rounded-full px-5 py-2.5 text-base font-semibold shadow transition hover:shadow-md",
-                  scrolled || open
+                  scrolled || open || isProductDetail
                     ? "bg-[hsl(var(--brand-end))] text-white"
                     : "bg-white text-slate-900",
                 )}
@@ -193,7 +194,7 @@ export default function Header() {
                 "md:hidden transition-colors",
                 open
                   ? "text-slate-900"
-                  : scrolled
+                  : scrolled || isProductDetail
                     ? "text-slate-700"
                     : "text-white",
               )}
@@ -272,9 +273,9 @@ export default function Header() {
                     to="/contact"
                     className={cn(
                       "block w-full rounded-full px-5 py-2.5 text-center text-base font-semibold shadow transition hover:shadow-md",
-                      scrolled || open
-                        ? "bg-[hsl(var(--brand-end))] text-white"
-                        : "bg-white text-slate-900",
+                      scrolled || open || isProductDetail
+                    ? "bg-[hsl(var(--brand-end))] text-white"
+                    : "bg-white text-slate-900",
                     )}
                     onClick={() => setOpen(false)}
                   >

--- a/client/components/ui/dialog.tsx
+++ b/client/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[10020] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/client/components/ui/dialog.tsx
+++ b/client/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[10010] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/client/components/ui/dialog.tsx
+++ b/client/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[10020] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[10020] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 max-h-[calc(100vh-6rem)] overflow-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/client/global.css
+++ b/client/global.css
@@ -138,7 +138,7 @@
   /* Use thin overlay scrollbars for webkit and firefox. These won't reserve layout width. */
   * {
     scrollbar-width: thin; /* Firefox: 'thin' typically shows overlay */
-    scrollbar-color: rgba(0,0,0,0.35) transparent; /* thumb, track */
+    scrollbar-color: rgba(0, 0, 0, 0.35) transparent; /* thumb, track */
   }
 
   /* WebKit scrollbar styling: thin overlay thumb, transparent track */
@@ -154,20 +154,21 @@
 
   /* Thumb styled to be visible on both light and dark backgrounds (semi-transparent) */
   *::-webkit-scrollbar-thumb {
-    background-color: rgba(0,0,0,0.35);
+    background-color: rgba(0, 0, 0, 0.35);
     border-radius: 9999px;
-    border: 1px solid rgba(255,255,255,0.0); /* no visible border */
+    border: 1px solid rgba(255, 255, 255, 0); /* no visible border */
     background-clip: padding-box;
   }
 
   /* Slightly darker on active/hover */
   *::-webkit-scrollbar-thumb:active,
   *::-webkit-scrollbar-thumb:hover {
-    background-color: rgba(0,0,0,0.5);
+    background-color: rgba(0, 0, 0, 0.5);
   }
 
   /* Ensure scrollbars are overlay (don't affect layout) - modern browsers do this by default on mobile */
-  html, body {
+  html,
+  body {
     -webkit-overflow-scrolling: touch;
   }
 

--- a/client/global.css
+++ b/client/global.css
@@ -176,3 +176,15 @@
     -webkit-overflow-scrolling: touch;
   }
 }
+
+/* Hide native scrollbars for thumbnail lists when using custom arrow controls */
+.no-scrollbar {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE 10+ */
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  width: 0; /* Safari/WebKit */
+  height: 0;
+  display: none;
+}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -604,7 +604,7 @@ function ProductCard({ product }: { product: Product }) {
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         onPointerMove={count > 1 ? handlePointerMove : undefined}
         onPointerEnter={() => count > 1 && setPreviewIndex(0)}
-        onPointerLeave={() => setPreviewIndex(null)}
+        onPointerLeave={() => { setPreviewIndex(null); if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null; lastIdxRef.current = null; } }}
         role="img"
         aria-label={product.title}
       >

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -403,7 +403,10 @@ export default function Catalog() {
                     <h2 className="text-xl font-bold">{category}</h2>
                     <div className="mt-4 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
                       {items.map((p) => (
-                        <ProductCard key={p.id} product={p} />
+                        <ProductCard key={p.id} product={p} onRequest={() => {
+                          setContactProduct(p);
+                          setContactModalOpen(true);
+                        }} />
                       ))}
                     </div>
                   </section>

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -705,13 +705,26 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         role="img"
         aria-label={product.title}
+        style={{ touchAction: "pan-y" }}
         onPointerMove={handlePointerMove}
         onPointerLeave={() => { if (!isTouch) setHoverIndex(null); }}
         onPointerCancel={() => { if (!isTouch) setHoverIndex(null); }}
         onPointerDown={onPointerDown}
-        onPointerMoveCapture={onPointerMove}
+        onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerCancel}
+        onTouchStart={(e) => {
+          if (!isTouch) return;
+          pointerRef.current = { startX: e.touches[0].clientX, lastX: e.touches[0].clientX, isDown: true };
+        }}
+        onTouchMove={(e) => {
+          if (!isTouch || !pointerRef.current?.isDown) return;
+          pointerRef.current.lastX = e.touches[0].clientX;
+        }}
+        onTouchEnd={(e) => {
+          if (!isTouch) return;
+          commitSwipe();
+        }}
         onClick={() => {
           /* keep click behavior if needed */
         }}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -573,28 +573,19 @@ function ProductCard({ product }: { product: Product }) {
 
   const displayed = previewIndex ?? 0;
 
-  const lastIdxRef = useRef<number | null>(null);
-  const rafRef = useRef<number | null>(null);
-
   function handlePointerMove(e: React.PointerEvent) {
     const el = containerRef.current;
     if (!el) return;
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    rafRef.current = requestAnimationFrame(() => {
-      const rect = el.getBoundingClientRect();
-      // use Y position relative to container for proportional slicing
-      let pos = e.clientY - rect.top;
-      if (pos < 0) pos = 0;
-      if (pos > rect.height) pos = rect.height;
-      const segment = rect.height / Math.max(1, count);
-      let idx = Math.floor(pos / (segment || 1));
-      if (idx < 0) idx = 0;
-      if (idx >= count) idx = count - 1;
-      if (lastIdxRef.current !== idx) {
-        lastIdxRef.current = idx;
-        setPreviewIndex(idx);
-      }
-    });
+    const rect = el.getBoundingClientRect();
+    // use Y position relative to container for proportional slicing
+    let pos = e.clientY - rect.top;
+    if (pos < 0) pos = 0;
+    if (pos > rect.height) pos = rect.height;
+    const segment = rect.height / Math.max(1, count);
+    let idx = Math.floor(pos / (segment || 1));
+    if (idx < 0) idx = 0;
+    if (idx >= count) idx = count - 1;
+    if (idx !== previewIndex) setPreviewIndex(idx);
   }
 
   return (

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -600,10 +600,19 @@ function ProductCard({ product }: { product: Product }) {
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         role="img"
         aria-label={product.title}
-        onPointerMove={count > 1 ? handlePointerMove : undefined}
-        onPointerEnter={() => count > 1 && setPreviewIndex(0)}
-        onPointerLeave={() => setPreviewIndex(null)}
-        onClick={() => { if (previewIndex != null) setCurrentIndex(previewIndex); }}
+        onPointerEnter={() => {
+          if (imgs.length > 1 && !hoverTimerRef.current) {
+            // start cycling every 700ms
+            hoverTimerRef.current = window.setInterval(handleImageHover, 700);
+          }
+        }}
+        onPointerLeave={() => {
+          if (hoverTimerRef.current) {
+            clearInterval(hoverTimerRef.current);
+            hoverTimerRef.current = null;
+          }
+        }}
+        onClick={() => { /* keep click behavior if needed */ }}
       >
         <img
           src={imgs[displayed]}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -576,7 +576,7 @@ function TagsDrawer({
   );
 }
 
-function ProductCard({ product }: { product: Product }) {
+function ProductCard({ product, onRequest }: { product: Product; onRequest?: () => void }) {
   const imgs = (product.mainImage ? [product.mainImage] : []).concat(
     product.images ?? [],
   );

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -573,16 +573,15 @@ function ProductCard({ product }: { product: Product }) {
 
   const displayed = previewIndex ?? 0;
 
-  function handleMove(e: React.MouseEvent) {
+  function handlePointerMove(e: React.PointerEvent) {
     const el = containerRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const y = e.clientY - rect.top;
-    // divide vertically into `count` zones
-    let idx = Math.floor((y / rect.height) * count);
-    if (idx < 0) idx = 0;
-    if (idx >= count) idx = count - 1;
-    setPreviewIndex(idx);
+    // use Y position relative to container for proportional slicing
+    const pos = e.clientY - rect.top;
+    const ratio = Math.min(Math.max(pos / (rect.height || 1), 0), 0.9999);
+    const idx = Math.floor(ratio * count);
+    if (idx !== previewIndex) setPreviewIndex(idx);
   }
 
   return (
@@ -590,9 +589,9 @@ function ProductCard({ product }: { product: Product }) {
       <div
         ref={containerRef}
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
-        onMouseMove={count > 1 ? handleMove : undefined}
-        onMouseEnter={() => count > 1 && setPreviewIndex(0)}
-        onMouseLeave={() => setPreviewIndex(null)}
+        onPointerMove={count > 1 ? handlePointerMove : undefined}
+        onPointerEnter={() => count > 1 && setPreviewIndex(0)}
+        onPointerLeave={() => setPreviewIndex(null)}
         role="img"
         aria-label={product.title}
       >

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -191,12 +191,24 @@ export default function Catalog() {
               <label className="block text-sm font-semibold text-slate-800">
                 Search
               </label>
-              <input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search products..."
-                className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
-              />
+              <div className="relative">
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search products..."
+                  className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 pr-9 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+                />
+                {query && (
+                  <button
+                    type="button"
+                    aria-label="Clear search"
+                    onClick={() => setQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-700 flex items-center justify-center"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
               <div className="flex gap-3 pt-1">
                 <button
                   onClick={() => setOpenCatSheet(true)}
@@ -268,12 +280,24 @@ export default function Catalog() {
                 <label className="block text-sm font-semibold text-slate-800">
                   Search
                 </label>
+                <div className="relative">
                 <input
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="Search products..."
-                  className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+                  className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 pr-9 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
                 />
+                {query && (
+                  <button
+                    type="button"
+                    aria-label="Clear search"
+                    onClick={() => setQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-700 flex items-center justify-center"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
               </div>
 
               {/* Tags above Categories */}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -16,6 +16,8 @@ type Product = {
   category: string;
   tags: string[];
   description: string;
+  mainImage?: string;
+  images?: string[];
 };
 
 const TAG_COLORS: Record<string, string> = {

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -604,6 +604,23 @@ function ProductCard({ product }: { product: Product }) {
             </span>
           ))}
         </div>
+
+        {imgs.length > 1 && (
+          <div className="absolute left-1/2 -translate-x-1/2 bottom-2 flex items-center gap-2">
+            {imgs.map((_, idx) => (
+              <span
+                key={idx}
+                aria-hidden
+                className={cn(
+                  "w-2 h-2 rounded-full transition-opacity",
+                  idx === displayed
+                    ? "bg-[hsl(var(--brand-end))] opacity-100"
+                    : "bg-white/60 opacity-70",
+                )}
+              />
+            ))}
+          </div>
+        )}
       </div>
       <div className="p-5">
         <h3 className="font-semibold text-lg">

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -671,12 +671,13 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
           </Badge>
         </div>
         <div className="mt-4 flex gap-2">
-          <Link
-            to="/contact"
+          <button
+            type="button"
+            onClick={() => onRequest ? onRequest() : undefined}
             className="inline-flex items-center rounded-lg bg-[hsl(var(--brand-end))] text-white px-3.5 py-2.5 text-sm font-semibold shadow"
           >
             Request quote
-          </Link>
+          </button>
           <Link
             to={`/products/${product.id}`}
             className="inline-flex items-center rounded-lg border border-slate-300 px-3.5 py-2.5 text-sm font-semibold hover:bg-slate-50"

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -574,7 +574,7 @@ function ProductCard({ product }: { product: Product }) {
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">
       <div
         ref={containerRef}
-        className="relative w-full aspect-[3/4] overflow-hidden rounded-xl bg-slate-50"
+        className="relative w-full aspect-[1/1] overflow-hidden rounded-xl bg-slate-50"
         onMouseMove={count > 1 ? handleMove : undefined}
         onMouseEnter={() => count > 1 && setPreviewIndex(0)}
         onMouseLeave={() => setPreviewIndex(null)}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -570,15 +570,27 @@ function ProductCard({ product }: { product: Product }) {
   );
   const count = Math.max(1, imgs.length);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // reset index when product changes
-  useEffect(() => setCurrentIndex(0), [product.id]);
+  useEffect(() => { setCurrentIndex(0); setPreviewIndex(null); }, [product.id]);
 
-  const displayed = currentIndex;
+  const displayed = previewIndex ?? currentIndex;
 
-  const prev = () => setCurrentIndex((i) => Math.max(0, i - 1));
-  const next = () => setCurrentIndex((i) => Math.min(count - 1, i + 1));
+  function handlePointerMove(e: React.PointerEvent) {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    let pos = e.clientY - rect.top;
+    if (pos < 0) pos = 0;
+    if (pos > rect.height) pos = rect.height;
+    const segment = rect.height / Math.max(1, count);
+    let idx = Math.floor(pos / (segment || 1));
+    if (idx < 0) idx = 0;
+    if (idx >= count) idx = count - 1;
+    if (idx !== previewIndex) setPreviewIndex(idx);
+  }
 
   return (
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -570,27 +570,28 @@ function ProductCard({ product }: { product: Product }) {
   );
   const count = Math.max(1, imgs.length);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const hoverTimerRef = useRef<number | null>(null);
 
   // reset index when product changes
-  useEffect(() => { setCurrentIndex(0); setPreviewIndex(null); }, [product.id]);
+  useEffect(() => { setCurrentIndex(0); }, [product.id]);
 
-  const displayed = previewIndex ?? currentIndex;
+  const displayed = currentIndex;
 
-  function handlePointerMove(e: React.PointerEvent) {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    let pos = e.clientY - rect.top;
-    if (pos < 0) pos = 0;
-    if (pos > rect.height) pos = rect.height;
-    const segment = rect.height / Math.max(1, count);
-    let idx = Math.floor(pos / (segment || 1));
-    if (idx < 0) idx = 0;
-    if (idx >= count) idx = count - 1;
-    if (idx !== previewIndex) setPreviewIndex(idx);
-  }
+  const handleImageHover = () => {
+    if (imgs.length > 1) {
+      setCurrentIndex((i) => (i + 1) % imgs.length);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) {
+        clearInterval(hoverTimerRef.current);
+        hoverTimerRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -706,11 +706,10 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
         role="img"
         aria-label={product.title}
         style={{ touchAction: "pan-y" }}
-        onPointerMove={handlePointerMove}
+        onPointerMove={(e) => { handlePointerMove(e); onPointerMove(e); }}
         onPointerLeave={() => { if (!isTouch) setHoverIndex(null); }}
         onPointerCancel={() => { if (!isTouch) setHoverIndex(null); }}
         onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerCancel}
         onTouchStart={(e) => {

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -574,7 +574,7 @@ function ProductCard({ product }: { product: Product }) {
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">
       <div
         ref={containerRef}
-        className="relative w-full aspect-[1/1] overflow-hidden rounded-xl bg-slate-50"
+        className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         onMouseMove={count > 1 ? handleMove : undefined}
         onMouseEnter={() => count > 1 && setPreviewIndex(0)}
         onMouseLeave={() => setPreviewIndex(null)}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -59,8 +59,12 @@ export default function Catalog() {
       try {
         setLoading(true);
         const tryFetch = async (url: string) => {
-          const res = await fetch(url, { headers: { "cache-control": "no-cache" }, credentials: "same-origin" });
-          if (!res.ok) throw new Error(`Failed to load products: ${res.status}`);
+          const res = await fetch(url, {
+            headers: { "cache-control": "no-cache" },
+            credentials: "same-origin",
+          });
+          if (!res.ok)
+            throw new Error(`Failed to load products: ${res.status}`);
           return (await res.json()) as Product[];
         };
 
@@ -70,7 +74,8 @@ export default function Catalog() {
         } catch (err) {
           // Attempt with absolute origin in case base path differs
           try {
-            const origin = typeof window !== "undefined" ? window.location.origin : "";
+            const origin =
+              typeof window !== "undefined" ? window.location.origin : "";
             if (origin) data = await tryFetch(origin + "/data/products.json");
           } catch (err2) {
             // no-op, will throw below
@@ -80,7 +85,8 @@ export default function Catalog() {
         if (!data) throw new Error("Failed to load products.json from server");
         if (!cancelled) setProducts(data);
       } catch (e: any) {
-        if (!cancelled) setError(String(e?.message || "Failed to load products"));
+        if (!cancelled)
+          setError(String(e?.message || "Failed to load products"));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -601,7 +607,9 @@ function ProductCard({ product }: { product: Product }) {
         onPointerMove={handlePointerMove}
         onPointerLeave={() => setHoverIndex(null)}
         onPointerCancel={() => setHoverIndex(null)}
-        onClick={() => { /* keep click behavior if needed */ }}
+        onClick={() => {
+          /* keep click behavior if needed */
+        }}
       >
         <img
           src={imgs[displayed]}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -657,45 +657,34 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
     setHoverIndex(idx);
   };
 
-  // swipe handling for touch devices
-  const pointerRef = useRef<{ startX?: number; lastX?: number; isDown?: boolean; pid?: number } | null>(null);
+  // swipe handling for touch devices - simplified: use touch events only to change activeIndex sequentially
+  const touchStartX = useRef<number | null>(null);
+  const touchLastX = useRef<number | null>(null);
 
-  const onPointerDown = (e: React.PointerEvent) => {
+  const onTouchStartSimple = (e: React.TouchEvent) => {
     if (!isTouch) return;
-    const el = e.currentTarget as HTMLDivElement;
-    try { el.setPointerCapture(e.pointerId); } catch {}
-    pointerRef.current = { startX: e.clientX, lastX: e.clientX, isDown: true, pid: e.pointerId };
+    touchStartX.current = e.touches[0].clientX;
+    touchLastX.current = e.touches[0].clientX;
   };
-  const onPointerMove = (e: React.PointerEvent) => {
+  const onTouchMoveSimple = (e: React.TouchEvent) => {
     if (!isTouch) return;
-    if (!pointerRef.current?.isDown) return;
-    pointerRef.current.lastX = e.clientX;
+    if (touchStartX.current === null) return;
+    touchLastX.current = e.touches[0].clientX;
   };
-  const commitSwipe = () => {
-    if (!pointerRef.current) return;
-    const { startX, lastX } = pointerRef.current;
-    pointerRef.current.isDown = false;
-    if (startX === undefined || lastX === undefined) return;
+  const onTouchEndSimple = (e?: React.TouchEvent) => {
+    if (!isTouch) return;
+    const startX = touchStartX.current;
+    const lastX = touchLastX.current;
+    touchStartX.current = null;
+    touchLastX.current = null;
+    if (startX === null || lastX === null) return;
     const dx = lastX - startX;
-    const threshold = 30; // pixels
+    const threshold = 30;
     if (dx < -threshold) {
       setActiveIndex((s) => (s + 1) % imgs.length);
     } else if (dx > threshold) {
       setActiveIndex((s) => (s - 1 + imgs.length) % imgs.length);
     }
-  };
-
-  const onPointerUp = (e: React.PointerEvent) => {
-    if (!isTouch) return;
-    const el = e.currentTarget as HTMLDivElement;
-    try { if (pointerRef.current?.pid !== undefined) el.releasePointerCapture(pointerRef.current.pid); } catch {}
-    commitSwipe();
-  };
-  const onPointerCancel = (e: React.PointerEvent) => {
-    if (!isTouch) return;
-    const el = e.currentTarget as HTMLDivElement;
-    try { if (pointerRef.current?.pid !== undefined) el.releasePointerCapture(pointerRef.current.pid); } catch {}
-    pointerRef.current = null;
   };
 
   return (

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useRef, useEffect } from "react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
 import { PageBanner } from "@/components/layout/PageBanner";
 import { Badge } from "@/components/ui/badge";

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -437,6 +437,15 @@ export default function Catalog() {
       />
 
       {/* Tags Drawer */}
+
+      <ContactModal
+        open={contactModalOpen}
+        productName={contactProduct?.title ?? null}
+        onOpenChange={(v) => {
+          setContactModalOpen(v);
+          if (!v) setContactProduct(null);
+        }}
+      />
       <TagsDrawer
         open={openTagSheet}
         onOpenChange={setOpenTagSheet}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -290,23 +290,23 @@ export default function Catalog() {
                   Search
                 </label>
                 <div className="relative">
-                <input
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="Search products..."
-                  className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 pr-9 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
-                />
-                {query && (
-                  <button
-                    type="button"
-                    aria-label="Clear search"
-                    onClick={() => setQuery("")}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-700 flex items-center justify-center"
-                  >
-                    ×
-                  </button>
-                )}
-              </div>
+                  <input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search products..."
+                    className="w-full h-10 rounded-lg bg-white text-slate-900 border border-slate-300 px-3 pr-9 outline-none focus:ring-2 focus:ring-[hsl(var(--brand-end))]"
+                  />
+                  {query && (
+                    <button
+                      type="button"
+                      aria-label="Clear search"
+                      onClick={() => setQuery("")}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-700 flex items-center justify-center"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
               </div>
 
               {/* Tags above Categories */}
@@ -440,10 +440,14 @@ export default function Catalog() {
                     <h2 className="text-xl font-bold">{category}</h2>
                     <div className="mt-4 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
                       {items.map((p) => (
-                        <ProductCard key={p.id} product={p} onRequest={() => {
-                          setContactProduct(p);
-                          setContactModalOpen(true);
-                        }} />
+                        <ProductCard
+                          key={p.id}
+                          product={p}
+                          onRequest={() => {
+                            setContactProduct(p);
+                            setContactModalOpen(true);
+                          }}
+                        />
                       ))}
                     </div>
                   </section>
@@ -619,7 +623,13 @@ function TagsDrawer({
   );
 }
 
-function ProductCard({ product, onRequest }: { product: Product; onRequest?: () => void }) {
+function ProductCard({
+  product,
+  onRequest,
+}: {
+  product: Product;
+  onRequest?: () => void;
+}) {
   const imgs = (product.mainImage ? [product.mainImage] : []).concat(
     product.images ?? [],
   );
@@ -630,7 +640,9 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
 
   // detect touch devices (mobile/tablet)
   useEffect(() => {
-    const touch = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+    const touch =
+      typeof window !== "undefined" &&
+      ("ontouchstart" in window || navigator.maxTouchPoints > 0);
     setIsTouch(Boolean(touch));
   }, []);
 
@@ -640,7 +652,7 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
     setActiveIndex(0);
   }, [product.id]);
 
-  const displayed = isTouch ? activeIndex : hoverIndex ?? activeIndex;
+  const displayed = isTouch ? activeIndex : (hoverIndex ?? activeIndex);
 
   // hover-based preview (desktop only)
   const handlePointerMove = (e: React.PointerEvent) => {
@@ -695,9 +707,15 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
         role="img"
         aria-label={product.title}
         style={{ touchAction: "pan-y" }}
-        onPointerMove={(e) => { handlePointerMove(e); }}
-        onPointerLeave={() => { if (!isTouch) setHoverIndex(null); }}
-        onPointerCancel={() => { if (!isTouch) setHoverIndex(null); }}
+        onPointerMove={(e) => {
+          handlePointerMove(e);
+        }}
+        onPointerLeave={() => {
+          if (!isTouch) setHoverIndex(null);
+        }}
+        onPointerCancel={() => {
+          if (!isTouch) setHoverIndex(null);
+        }}
         onTouchStart={onTouchStartSimple}
         onTouchMove={onTouchMoveSimple}
         onTouchEnd={onTouchEndSimple}
@@ -761,7 +779,7 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
         <div className="mt-4 flex gap-2">
           <button
             type="button"
-            onClick={() => onRequest ? onRequest() : undefined}
+            onClick={() => (onRequest ? onRequest() : undefined)}
             className="inline-flex items-center rounded-lg bg-[hsl(var(--brand-end))] text-white px-3.5 py-2.5 text-sm font-semibold shadow"
           >
             Request quote

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -574,7 +574,7 @@ function ProductCard({ product }: { product: Product }) {
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">
       <div
         ref={containerRef}
-        className="relative h-40 bg-slate-50 overflow-hidden"
+        className="relative w-full aspect-[3/4] overflow-hidden rounded-xl bg-slate-50"
         onMouseMove={count > 1 ? handleMove : undefined}
         onMouseEnter={() => count > 1 && setPreviewIndex(0)}
         onMouseLeave={() => setPreviewIndex(null)}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -171,6 +171,9 @@ export default function Catalog() {
     });
   };
 
+  const [contactModalOpen, setContactModalOpen] = useState(false);
+  const [contactProduct, setContactProduct] = useState<Product | null>(null);
+
   return (
     <div className="bg-white text-slate-900">
       <PageBanner

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -595,7 +595,7 @@ function ProductCard({ product }: { product: Product }) {
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         onPointerMove={count > 1 ? handlePointerMove : undefined}
         onPointerEnter={() => count > 1 && setPreviewIndex(0)}
-        onPointerLeave={() => { setPreviewIndex(null); if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null; lastIdxRef.current = null; } }}
+        onPointerLeave={() => { setPreviewIndex(null); }}
         role="img"
         aria-label={product.title}
       >

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -585,9 +585,6 @@ function ProductCard({ product }: { product: Product }) {
       <div
         ref={containerRef}
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
-        onPointerMove={count > 1 ? handlePointerMove : undefined}
-        onPointerEnter={() => count > 1 && setPreviewIndex(0)}
-        onPointerLeave={() => { setPreviewIndex(null); }}
         role="img"
         aria-label={product.title}
       >
@@ -596,10 +593,28 @@ function ProductCard({ product }: { product: Product }) {
           alt={product.title}
           className="absolute inset-0 h-full w-full object-cover"
           style={{ left: 0, top: 0 }}
-          onLoad={() => {
-            // no-op; keeps image loading behavior
-          }}
         />
+
+        {count > 1 && (
+          <>
+            <button
+              aria-label="Previous image"
+              onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
+              disabled={currentIndex === 0}
+              className="absolute left-2 top-1/2 -translate-y-1/2 z-20 h-8 w-8 rounded-full bg-white/80 text-slate-700 flex items-center justify-center disabled:opacity-40"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </button>
+            <button
+              aria-label="Next image"
+              onClick={() => setCurrentIndex((i) => Math.min(count - 1, i + 1))}
+              disabled={currentIndex === count - 1}
+              className="absolute right-2 top-1/2 -translate-y-1/2 z-20 h-8 w-8 rounded-full bg-white/80 text-slate-700 flex items-center justify-center disabled:opacity-40"
+            >
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </>
+        )}
         <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_30%_20%,white,transparent_35%),radial-gradient(circle_at_70%_80%,white,transparent_25%)]" />
         <div className="absolute top-3 left-3 flex flex-wrap gap-2">
           {product.tags.map((t) => (

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -577,20 +577,8 @@ function ProductCard({ product }: { product: Product }) {
 
   const displayed = currentIndex;
 
-  function handlePointerMove(e: React.PointerEvent) {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    // use Y position relative to container for proportional slicing
-    let pos = e.clientY - rect.top;
-    if (pos < 0) pos = 0;
-    if (pos > rect.height) pos = rect.height;
-    const segment = rect.height / Math.max(1, count);
-    let idx = Math.floor(pos / (segment || 1));
-    if (idx < 0) idx = 0;
-    if (idx >= count) idx = count - 1;
-    if (idx !== previewIndex) setPreviewIndex(idx);
-  }
+  const prev = () => setCurrentIndex((i) => Math.max(0, i - 1));
+  const next = () => setCurrentIndex((i) => Math.min(count - 1, i + 1));
 
   return (
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -175,6 +175,15 @@ export default function Catalog() {
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [contactProduct, setContactProduct] = useState<Product | null>(null);
 
+  const _filtersDidMount = useRef(true);
+  useEffect(() => {
+    if (_filtersDidMount.current) {
+      _filtersDidMount.current = false;
+      return;
+    }
+    scrollToProducts();
+  }, [selectedCategory, query, selectedTags]);
+
   return (
     <div className="bg-white text-slate-900">
       <PageBanner

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -599,6 +599,10 @@ function ProductCard({ product }: { product: Product }) {
         className="relative w-full aspect-[1/1] overflow-hidden rounded-t-2xl bg-slate-50"
         role="img"
         aria-label={product.title}
+        onPointerMove={count > 1 ? handlePointerMove : undefined}
+        onPointerEnter={() => count > 1 && setPreviewIndex(0)}
+        onPointerLeave={() => setPreviewIndex(null)}
+        onClick={() => { if (previewIndex != null) setCurrentIndex(previewIndex); }}
       >
         <img
           src={imgs[displayed]}
@@ -606,27 +610,6 @@ function ProductCard({ product }: { product: Product }) {
           className="absolute inset-0 h-full w-full object-cover"
           style={{ left: 0, top: 0 }}
         />
-
-        {count > 1 && (
-          <>
-            <button
-              aria-label="Previous image"
-              onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
-              disabled={currentIndex === 0}
-              className="absolute left-2 top-1/2 -translate-y-1/2 z-20 h-8 w-8 rounded-full bg-white/80 text-slate-700 flex items-center justify-center disabled:opacity-40"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </button>
-            <button
-              aria-label="Next image"
-              onClick={() => setCurrentIndex((i) => Math.min(count - 1, i + 1))}
-              disabled={currentIndex === count - 1}
-              className="absolute right-2 top-1/2 -translate-y-1/2 z-20 h-8 w-8 rounded-full bg-white/80 text-slate-700 flex items-center justify-center disabled:opacity-40"
-            >
-              <ArrowRight className="h-4 w-4" />
-            </button>
-          </>
-        )}
         <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_30%_20%,white,transparent_35%),radial-gradient(circle_at_70%_80%,white,transparent_25%)]" />
         <div className="absolute top-3 left-3 flex flex-wrap gap-2">
           {product.tags.map((t) => (

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -695,24 +695,12 @@ function ProductCard({ product, onRequest }: { product: Product; onRequest?: () 
         role="img"
         aria-label={product.title}
         style={{ touchAction: "pan-y" }}
-        onPointerMove={(e) => { handlePointerMove(e); onPointerMove(e); }}
+        onPointerMove={(e) => { handlePointerMove(e); }}
         onPointerLeave={() => { if (!isTouch) setHoverIndex(null); }}
         onPointerCancel={() => { if (!isTouch) setHoverIndex(null); }}
-        onPointerDown={onPointerDown}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerCancel}
-        onTouchStart={(e) => {
-          if (!isTouch) return;
-          pointerRef.current = { startX: e.touches[0].clientX, lastX: e.touches[0].clientX, isDown: true };
-        }}
-        onTouchMove={(e) => {
-          if (!isTouch || !pointerRef.current?.isDown) return;
-          pointerRef.current.lastX = e.touches[0].clientX;
-        }}
-        onTouchEnd={(e) => {
-          if (!isTouch) return;
-          commitSwipe();
-        }}
+        onTouchStart={onTouchStartSimple}
+        onTouchMove={onTouchMoveSimple}
+        onTouchEnd={onTouchEndSimple}
         onClick={() => {
           /* keep click behavior if needed */
         }}

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -549,9 +549,47 @@ function TagsDrawer({
 }
 
 function ProductCard({ product }: { product: Product }) {
+  const imgs = (product.mainImage ? [product.mainImage] : []).concat(
+    product.images ?? [],
+  );
+  const count = Math.max(1, imgs.length);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const displayed = previewIndex ?? 0;
+
+  function handleMove(e: React.MouseEvent) {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    // divide vertically into `count` zones
+    let idx = Math.floor((y / rect.height) * count);
+    if (idx < 0) idx = 0;
+    if (idx >= count) idx = count - 1;
+    setPreviewIndex(idx);
+  }
+
   return (
     <div className="group overflow-hidden rounded-2xl border border-slate-200 bg-white">
-      <div className="relative h-40 bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]">
+      <div
+        ref={containerRef}
+        className="relative h-40 bg-slate-50 overflow-hidden"
+        onMouseMove={count > 1 ? handleMove : undefined}
+        onMouseEnter={() => count > 1 && setPreviewIndex(0)}
+        onMouseLeave={() => setPreviewIndex(null)}
+        role="img"
+        aria-label={product.title}
+      >
+        <img
+          src={imgs[displayed]}
+          alt={product.title}
+          className="absolute inset-0 h-full w-full object-cover"
+          style={{ left: 0, top: 0 }}
+          onLoad={() => {
+            // no-op; keeps image loading behavior
+          }}
+        />
         <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_30%_20%,white,transparent_35%),radial-gradient(circle_at_70%_80%,white,transparent_25%)]" />
         <div className="absolute top-3 left-3 flex flex-wrap gap-2">
           {product.tags.map((t) => (

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -569,10 +569,13 @@ function ProductCard({ product }: { product: Product }) {
     product.images ?? [],
   );
   const count = Math.max(1, imgs.length);
-  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const displayed = previewIndex ?? 0;
+  // reset index when product changes
+  useEffect(() => setCurrentIndex(0), [product.id]);
+
+  const displayed = currentIndex;
 
   function handlePointerMove(e: React.PointerEvent) {
     const el = containerRef.current;

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
 import { PageBanner } from "@/components/layout/PageBanner";
 import { Badge } from "@/components/ui/badge";
+import ContactModal from "@/components/ContactModal";
 import { cn } from "@/lib/utils";
 import {
   Sheet,

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -116,6 +116,20 @@ export default function ProductPage() {
   );
   const [mainAspect, setMainAspect] = useState<string | undefined>(undefined);
   const [thumbsOverflow, setThumbsOverflow] = useState(false);
+  const [thumbsCanScrollUp, setThumbsCanScrollUp] = useState(false);
+  const [thumbsCanScrollDown, setThumbsCanScrollDown] = useState(false);
+
+  const updateThumbsScrollState = (thumbsEl: HTMLDivElement | null) => {
+    if (!thumbsEl) {
+      setThumbsCanScrollUp(false);
+      setThumbsCanScrollDown(false);
+      return;
+    }
+    const { scrollTop, clientHeight, scrollHeight } = thumbsEl;
+    const eps = 1;
+    setThumbsCanScrollUp(scrollTop > eps);
+    setThumbsCanScrollDown(scrollTop + clientHeight < scrollHeight - eps);
+  };
 
   const updateSizes = () => {
     const el = mainImageRef.current;
@@ -127,10 +141,12 @@ export default function ProductPage() {
 
       const thumbsEl = thumbsRef.current;
       setThumbsOverflow(thumbsEl ? thumbsEl.scrollHeight > (thumbsEl.clientHeight + 1) : false);
+      updateThumbsScrollState(thumbsEl);
     } else {
       setThumbsMaxHeight(undefined);
       setMainAspect(undefined);
       setThumbsOverflow(false);
+      updateThumbsScrollState(null);
     }
   };
 

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -206,12 +206,12 @@ export default function ProductPage() {
                           <button
                             key={src + i}
                             className={cn(
-                              "relative w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
+                              "relative aspect-[1/1] w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
                               i === activeIndex
                                 ? "border-2 border-[hsl(var(--brand-end))]"
                                 : "border border-transparent",
                             )}
-                            style={mainAspect ? { aspectRatio: mainAspect } : undefined}
+                            style={{ aspectRatio: '1 / 1' }}
                             onMouseEnter={() => setPreviewIndex(i)}
                             onMouseLeave={() => setPreviewIndex(null)}
                             onFocus={() => setPreviewIndex(i)}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -174,13 +174,14 @@ export default function ProductPage() {
                   {/* Thumbnails left (vertical) */}
                   <div className="col-span-2 relative">
                     <div
-                      className="max-h-[300px] overflow-y-auto pr-1"
+                      className="overflow-y-auto pr-1"
                       ref={(el) => {
-                        // no-op ref; buttons below scroll this element via document.getElementById
+                        thumbsRef.current = el;
                       }}
                       id="thumbs-scroll"
                       role="tablist"
                       aria-label="Product image thumbnails"
+                      style={thumbsMaxHeight ? { maxHeight: `${thumbsMaxHeight}px` } : undefined}
                     >
                       <div className="flex flex-col gap-1">
                         {gallery.map((src, i) => (

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -277,7 +277,7 @@ export default function ProductPage() {
                             "w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
                             i === displayedIndex ? "block" : "hidden",
                           )}
-                          style={mainAspect ? { aspectRatio: mainAspect } : undefined}
+                          style={{ aspectRatio: '1 / 1' }}
                         >
                           <img
                             src={src}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -45,14 +45,28 @@ export default function ProductPage() {
     (async () => {
       try {
         setLoading(true);
-        const res = await fetch("/data/products.json", {
-          headers: { "cache-control": "no-cache" },
-        });
-        if (!res.ok) throw new Error(`Failed to load products: ${res.status}`);
-        const data: Product[] = await res.json();
+        const tryFetch = async (url: string) => {
+          const res = await fetch(url, { headers: { "cache-control": "no-cache" }, credentials: "same-origin" });
+          if (!res.ok) throw new Error(`Failed to load products: ${res.status}`);
+          return (await res.json()) as Product[];
+        };
+
+        let data: Product[] | null = null;
+        try {
+          data = await tryFetch("/data/products.json");
+        } catch (err) {
+          try {
+            const origin = typeof window !== "undefined" ? window.location.origin : "";
+            if (origin) data = await tryFetch(origin + "/data/products.json");
+          } catch (err2) {
+            // no-op
+          }
+        }
+
+        if (!data) throw new Error("Failed to load products.json from server");
         if (!cancelled) setProducts(data);
       } catch (e: any) {
-        if (!cancelled) setError(e?.message || "Failed to load product");
+        if (!cancelled) setError(String(e?.message || "Failed to load product"));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -90,32 +90,28 @@ export default function ProductPage() {
   const [mainAspect, setMainAspect] = useState<string | undefined>(undefined);
   const [thumbsOverflow, setThumbsOverflow] = useState(false);
 
-  useLayoutEffect(() => {
-    function update() {
-      const el = mainImageRef.current;
-      if (el) {
-        const mainH = el.clientHeight;
-        setThumbsMaxHeight(mainH);
-        const rect = el.getBoundingClientRect();
-        setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
+  const updateSizes = () => {
+    const el = mainImageRef.current;
+    if (el) {
+      const mainH = el.clientHeight;
+      setThumbsMaxHeight(mainH);
+      const rect = el.getBoundingClientRect();
+      setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
 
-        // measure thumbs overflow synchronously
-        const thumbsEl = thumbsRef.current;
-        if (thumbsEl) {
-          // If thumbnails total height exceeds main image height, enable arrows
-          setThumbsOverflow(thumbsEl.scrollHeight > mainH + 1);
-        } else {
-          setThumbsOverflow(false);
-        }
-      } else {
-        setThumbsMaxHeight(undefined);
-        setMainAspect(undefined);
-        setThumbsOverflow(false);
-      }
+      const thumbsEl = thumbsRef.current;
+      setThumbsOverflow(thumbsEl ? thumbsEl.scrollHeight > mainH + 1 : false);
+    } else {
+      setThumbsMaxHeight(undefined);
+      setMainAspect(undefined);
+      setThumbsOverflow(false);
     }
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
+  };
+
+  useLayoutEffect(() => {
+    // run once after DOM mutations; images may not be loaded yet
+    updateSizes();
+    window.addEventListener("resize", updateSizes);
+    return () => window.removeEventListener("resize", updateSizes);
   }, [activeIndex, product?.id, gallery.length]);
 
   useEffect(() => setActiveIndex(0), [product?.id]);

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -57,7 +57,11 @@ export default function ProductPage() {
             });
             clearTimeout(timeout);
             if (!res.ok) {
-              console.warn("Failed to load products (status):", res.status, url);
+              console.warn(
+                "Failed to load products (status):",
+                res.status,
+                url,
+              );
               return null;
             }
             try {
@@ -68,7 +72,11 @@ export default function ProductPage() {
             }
           } catch (e: any) {
             // fetch failed (network error, CORS, aborted, etc.)
-            console.warn("Fetch error for", url, e && e.message ? e.message : e);
+            console.warn(
+              "Fetch error for",
+              url,
+              e && e.message ? e.message : e,
+            );
             return null;
           }
         };
@@ -77,7 +85,8 @@ export default function ProductPage() {
         data = await tryFetch("/data/products.json");
         if (!data) {
           try {
-            const origin = typeof window !== "undefined" ? window.location.origin : "";
+            const origin =
+              typeof window !== "undefined" ? window.location.origin : "";
             if (origin) data = await tryFetch(origin + "/data/products.json");
           } catch (err2) {
             // no-op
@@ -155,7 +164,9 @@ export default function ProductPage() {
       setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
 
       const thumbsEl = thumbsRef.current;
-      setThumbsOverflow(thumbsEl ? thumbsEl.scrollHeight > (thumbsEl.clientHeight + 1) : false);
+      setThumbsOverflow(
+        thumbsEl ? thumbsEl.scrollHeight > thumbsEl.clientHeight + 1 : false,
+      );
       updateThumbsScrollState(thumbsEl);
     } else {
       setThumbsMaxHeight(undefined);
@@ -172,11 +183,13 @@ export default function ProductPage() {
 
     const thumbsEl = thumbsRef.current;
     const onThumbsScroll = () => updateThumbsScrollState(thumbsEl);
-    if (thumbsEl) thumbsEl.addEventListener("scroll", onThumbsScroll, { passive: true });
+    if (thumbsEl)
+      thumbsEl.addEventListener("scroll", onThumbsScroll, { passive: true });
 
     return () => {
       window.removeEventListener("resize", updateSizes);
-      if (thumbsEl) thumbsEl.removeEventListener("scroll", onThumbsScroll as any);
+      if (thumbsEl)
+        thumbsEl.removeEventListener("scroll", onThumbsScroll as any);
     };
   }, [activeIndex, product?.id, gallery.length]);
 
@@ -350,7 +363,9 @@ export default function ProductPage() {
                       style={{ touchAction: "pan-y" }}
                       onPointerDown={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
-                        try { el.setPointerCapture(e.pointerId); } catch {}
+                        try {
+                          el.setPointerCapture(e.pointerId);
+                        } catch {}
                         (el as any)._startX = e.clientX;
                         (el as any)._lastX = e.clientX;
                         (el as any)._isDown = true;
@@ -365,8 +380,13 @@ export default function ProductPage() {
                         const el = e.currentTarget as HTMLDivElement;
                         if (!(el as any)._isDown) return;
                         (el as any)._isDown = false;
-                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
-                        const startX = (el as any)._startX as number | undefined;
+                        try {
+                          if ((el as any)._pointerId !== undefined)
+                            el.releasePointerCapture((el as any)._pointerId);
+                        } catch {}
+                        const startX = (el as any)._startX as
+                          | number
+                          | undefined;
                         const lastX = (el as any)._lastX as number | undefined;
                         if (startX === undefined || lastX === undefined) return;
                         const dx = lastX - startX;
@@ -374,19 +394,27 @@ export default function ProductPage() {
                         if (dx < -threshold) {
                           setActiveIndex((s) => (s + 1) % gallery.length);
                         } else if (dx > threshold) {
-                          setActiveIndex((s) => (s - 1 + gallery.length) % gallery.length);
+                          setActiveIndex(
+                            (s) => (s - 1 + gallery.length) % gallery.length,
+                          );
                         }
                       }}
                       onPointerCancel={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
                         (el as any)._isDown = false;
-                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
+                        try {
+                          if ((el as any)._pointerId !== undefined)
+                            el.releasePointerCapture((el as any)._pointerId);
+                        } catch {}
                       }}
                       onPointerLeave={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
                         if (!(el as any)._isDown) return;
                         (el as any)._isDown = false;
-                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
+                        try {
+                          if ((el as any)._pointerId !== undefined)
+                            el.releasePointerCapture((el as any)._pointerId);
+                        } catch {}
                       }}
                     >
                       {/* Mobile counter */}
@@ -550,9 +578,24 @@ export default function ProductPage() {
             "@type": "BreadcrumbList",
             itemListElement: [
               { "@type": "ListItem", position: 1, name: "Home", item: "/" },
-              { "@type": "ListItem", position: 2, name: "Products", item: "/products" },
-              { "@type": "ListItem", position: 3, name: product.category, item: categoryLink },
-              { "@type": "ListItem", position: 4, name: product.title, item: location.pathname },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "Products",
+                item: "/products",
+              },
+              {
+                "@type": "ListItem",
+                position: 3,
+                name: product.category,
+                item: categoryLink,
+              },
+              {
+                "@type": "ListItem",
+                position: 4,
+                name: product.title,
+                item: location.pathname,
+              },
             ],
           }),
         }}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -173,7 +173,7 @@ export default function ProductPage() {
                           <button
                             key={src + i}
                             className={cn(
-                              "relative h-14 w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
+                              "relative aspect-[3/4] w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
                               i === activeIndex
                                 ? "border-2 border-[hsl(var(--brand-end))]"
                                 : "border border-transparent",
@@ -233,7 +233,7 @@ export default function ProductPage() {
                           key={src + i}
                           id={`slide-${i}`}
                           className={cn(
-                            "aspect-[16/10] w-full overflow-hidden rounded-xl bg-slate-50",
+                            "aspect-[3/4] w-full overflow-hidden rounded-xl bg-slate-50",
                             i === activeIndex ? "block" : "hidden",
                           )}
                         >
@@ -251,7 +251,7 @@ export default function ProductPage() {
               </div>
             ) : (
               <div className="p-0">
-                <div className="aspect-[16/10] w-full overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
+                <div className="aspect-[3/4] w-full overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
               </div>
             )}
           </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -161,18 +161,12 @@ export default function ProductPage() {
       <div className="bg-white text-slate-900">
         <div className="container mx-auto px-4 py-10">
           <p className="text-slate-700">We couldn't find this product.</p>
-          <div className="mt-4">
-            <Link
-              to="/products"
-              className="text-[hsl(var(--brand-end))] hover:underline"
-            >
-              Back to Products
-            </Link>
-          </div>
         </div>
       </div>
     );
   }
+
+  const categoryLink = `/products?category=${encodeURIComponent(product.category)}`;
 
   return (
     <div className="bg-white text-slate-900">
@@ -195,6 +189,12 @@ export default function ProductPage() {
             <BreadcrumbItem>
               <BreadcrumbLink asChild>
                 <Link to="/products">Products</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={categoryLink}>{product.category}</Link>
               </BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
@@ -374,22 +374,6 @@ export default function ProductPage() {
                 </Link>
               </div>
 
-              <div className="mt-6">
-                <h3 className="text-sm font-semibold text-slate-800">
-                  Details
-                </h3>
-                <dl className="mt-3 space-y-2 text-sm">
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">ID</dt>
-                    <dd className="text-slate-800">{product.id}</dd>
-                  </div>
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">Category</dt>
-                    <dd className="text-slate-800">{product.category}</dd>
-                  </div>
-                </dl>
-              </div>
-
               {product.brochures && product.brochures.length > 0 && (
                 <div className="mt-8">
                   <h3 className="text-sm font-semibold text-slate-800">
@@ -467,18 +451,9 @@ export default function ProductPage() {
             "@type": "BreadcrumbList",
             itemListElement: [
               { "@type": "ListItem", position: 1, name: "Home", item: "/" },
-              {
-                "@type": "ListItem",
-                position: 2,
-                name: "Products",
-                item: "/products",
-              },
-              {
-                "@type": "ListItem",
-                position: 3,
-                name: product.title,
-                item: location.pathname,
-              },
+              { "@type": "ListItem", position: 2, name: "Products", item: "/products" },
+              { "@type": "ListItem", position: 3, name: product.category, item: categoryLink },
+              { "@type": "ListItem", position: 4, name: product.title, item: location.pathname },
             ],
           }),
         }}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -260,9 +260,10 @@ export default function ProductPage() {
                             if (i === activeIndex) mainImageRef.current = el;
                           }}
                           className={cn(
-                            "aspect-[3/4] w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
+                            "w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
                             i === activeIndex ? "block" : "hidden",
                           )}
+                          style={mainAspect ? { aspectRatio: mainAspect } : undefined}
                         >
                           <img
                             src={src}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -153,14 +153,14 @@ export default function ProductPage() {
       <div className="container mx-auto px-4 pb-10">
         <div className="grid gap-8 lg:grid-cols-12">
           {/* Left: Gallery Slider */}
-          <div className="lg:col-span-7">
+          <div className="lg:col-span-6">
             {gallery.length > 0 ? (
               <div className="relative p-0">
                 <div className="grid grid-cols-12 gap-4 items-start">
                   {/* Thumbnails left (vertical) */}
                   <div className="col-span-2 relative">
                     <div
-                      className="max-h-[420px] overflow-y-auto pr-1"
+                      className="max-h-[300px] overflow-y-auto pr-1"
                       ref={(el) => {
                         // no-op ref; buttons below scroll this element via document.getElementById
                       }}
@@ -233,7 +233,7 @@ export default function ProductPage() {
                           key={src + i}
                           id={`slide-${i}`}
                           className={cn(
-                            "aspect-[3/4] w-full overflow-hidden rounded-xl bg-slate-50",
+                            "aspect-[3/4] w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
                             i === activeIndex ? "block" : "hidden",
                           )}
                         >
@@ -251,7 +251,7 @@ export default function ProductPage() {
               </div>
             ) : (
               <div className="p-0">
-                <div className="aspect-[3/4] w-full overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
+                <div className="aspect-[3/4] w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
               </div>
             )}
           </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -83,6 +83,8 @@ export default function ProductPage() {
   }, [product]);
 
   const [activeIndex, setActiveIndex] = useState(0);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const displayedIndex = previewIndex ?? activeIndex;
 
   const mainImageRef = useRef<HTMLDivElement | null>(null);
   const thumbsRef = useRef<HTMLDivElement | null>(null);
@@ -210,8 +212,10 @@ export default function ProductPage() {
                                 : "border border-transparent",
                             )}
                             style={mainAspect ? { aspectRatio: mainAspect } : undefined}
-                            onMouseEnter={() => setActiveIndex(i)}
-                            onFocus={() => setActiveIndex(i)}
+                            onMouseEnter={() => setPreviewIndex(i)}
+                            onMouseLeave={() => setPreviewIndex(null)}
+                            onFocus={() => setPreviewIndex(i)}
+                            onBlur={() => setPreviewIndex(null)}
                             onClick={() => setActiveIndex(i)}
                             role="tab"
                             aria-selected={i === activeIndex}
@@ -267,11 +271,11 @@ export default function ProductPage() {
                           key={src + i}
                           id={`slide-${i}`}
                           ref={(el) => {
-                            if (i === activeIndex) mainImageRef.current = el;
+                            if (i === displayedIndex) mainImageRef.current = el;
                           }}
                           className={cn(
                             "w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
-                            i === activeIndex ? "block" : "hidden",
+                            i === displayedIndex ? "block" : "hidden",
                           )}
                           style={mainAspect ? { aspectRatio: mainAspect } : undefined}
                         >

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -46,8 +46,12 @@ export default function ProductPage() {
       try {
         setLoading(true);
         const tryFetch = async (url: string) => {
-          const res = await fetch(url, { headers: { "cache-control": "no-cache" }, credentials: "same-origin" });
-          if (!res.ok) throw new Error(`Failed to load products: ${res.status}`);
+          const res = await fetch(url, {
+            headers: { "cache-control": "no-cache" },
+            credentials: "same-origin",
+          });
+          if (!res.ok)
+            throw new Error(`Failed to load products: ${res.status}`);
           return (await res.json()) as Product[];
         };
 
@@ -56,7 +60,8 @@ export default function ProductPage() {
           data = await tryFetch("/data/products.json");
         } catch (err) {
           try {
-            const origin = typeof window !== "undefined" ? window.location.origin : "";
+            const origin =
+              typeof window !== "undefined" ? window.location.origin : "";
             if (origin) data = await tryFetch(origin + "/data/products.json");
           } catch (err2) {
             // no-op
@@ -66,7 +71,8 @@ export default function ProductPage() {
         if (!data) throw new Error("Failed to load products.json from server");
         if (!cancelled) setProducts(data);
       } catch (e: any) {
-        if (!cancelled) setError(String(e?.message || "Failed to load product"));
+        if (!cancelled)
+          setError(String(e?.message || "Failed to load product"));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -102,7 +108,9 @@ export default function ProductPage() {
 
   const mainImageRef = useRef<HTMLDivElement | null>(null);
   const thumbsRef = useRef<HTMLDivElement | null>(null);
-  const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(undefined);
+  const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(
+    undefined,
+  );
   const [mainAspect, setMainAspect] = useState<string | undefined>(undefined);
   const [thumbsOverflow, setThumbsOverflow] = useState(false);
 
@@ -213,7 +221,11 @@ export default function ProductPage() {
                       id="thumbs-scroll"
                       role="tablist"
                       aria-label="Product image thumbnails"
-                      style={thumbsMaxHeight ? { maxHeight: `${thumbsMaxHeight}px` } : undefined}
+                      style={
+                        thumbsMaxHeight
+                          ? { maxHeight: `${thumbsMaxHeight}px` }
+                          : undefined
+                      }
                     >
                       <div className="flex flex-col gap-1">
                         {gallery.map((src, i) => (
@@ -225,7 +237,7 @@ export default function ProductPage() {
                                 ? "border-2 border-[hsl(var(--brand-end))]"
                                 : "border border-transparent",
                             )}
-                            style={{ aspectRatio: '1 / 1' }}
+                            style={{ aspectRatio: "1 / 1" }}
                             onMouseEnter={() => setPreviewIndex(i)}
                             onMouseLeave={() => setPreviewIndex(null)}
                             onFocus={() => setPreviewIndex(i)}
@@ -255,7 +267,9 @@ export default function ProductPage() {
                           aria-label="Scroll thumbnails up"
                           onClick={() => {
                             const el = thumbsRef.current;
-                            const step = Math.round((thumbsMaxHeight || 120) * 0.5);
+                            const step = Math.round(
+                              (thumbsMaxHeight || 120) * 0.5,
+                            );
                             el?.scrollBy({ top: -step, behavior: "smooth" });
                           }}
                         >
@@ -267,7 +281,9 @@ export default function ProductPage() {
                           aria-label="Scroll thumbnails down"
                           onClick={() => {
                             const el = thumbsRef.current;
-                            const step = Math.round((thumbsMaxHeight || 120) * 0.5);
+                            const step = Math.round(
+                              (thumbsMaxHeight || 120) * 0.5,
+                            );
                             el?.scrollBy({ top: step, behavior: "smooth" });
                           }}
                         >
@@ -291,7 +307,7 @@ export default function ProductPage() {
                             "w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
                             i === displayedIndex ? "block" : "hidden",
                           )}
-                          style={{ aspectRatio: '1 / 1' }}
+                          style={{ aspectRatio: "1 / 1" }}
                         >
                           <img
                             src={src}
@@ -308,7 +324,10 @@ export default function ProductPage() {
               </div>
             ) : (
               <div className="p-0">
-                <div className="w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" style={{ aspectRatio: '1 / 1' }} />
+                <div
+                  className="w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]"
+                  style={{ aspectRatio: "1 / 1" }}
+                />
               </div>
             )}
           </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -194,7 +194,7 @@ export default function ProductPage() {
                   {/* Thumbnails left (vertical) */}
                   <div className="col-span-2 relative">
                     <div
-                      className="overflow-y-auto pr-1"
+                      className="overflow-y-auto pr-1 no-scrollbar"
                       ref={(el) => {
                         thumbsRef.current = el;
                       }}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -233,15 +233,16 @@ export default function ProductPage() {
                       </div>
                     </div>
                     {/* Vertical scroll controls (up/down) */}
-                    {gallery.length > 5 && (
+                    {thumbsOverflow && (
                       <>
                         <button
                           type="button"
                           className="absolute -top-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
                           aria-label="Scroll thumbnails up"
                           onClick={() => {
-                            const el = document.getElementById("thumbs-scroll");
-                            el?.scrollBy({ top: -120, behavior: "smooth" });
+                            const el = thumbsRef.current;
+                            const step = Math.round((thumbsMaxHeight || 120) * 0.5);
+                            el?.scrollBy({ top: -step, behavior: "smooth" });
                           }}
                         >
                           <ArrowUp className="h-4 w-4 mx-auto" />
@@ -251,8 +252,9 @@ export default function ProductPage() {
                           className="absolute -bottom-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
                           aria-label="Scroll thumbnails down"
                           onClick={() => {
-                            const el = document.getElementById("thumbs-scroll");
-                            el?.scrollBy({ top: 120, behavior: "smooth" });
+                            const el = thumbsRef.current;
+                            const step = Math.round((thumbsMaxHeight || 120) * 0.5);
+                            el?.scrollBy({ top: step, behavior: "smooth" });
                           }}
                         >
                           <ArrowDown className="h-4 w-4 mx-auto" />

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useParams } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { Seo } from "@/components/Seo";
+import ContactModal from "@/components/ContactModal";
 import {
   Breadcrumb,
   BreadcrumbList,

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -88,17 +88,29 @@ export default function ProductPage() {
   const thumbsRef = useRef<HTMLDivElement | null>(null);
   const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(undefined);
   const [mainAspect, setMainAspect] = useState<string | undefined>(undefined);
+  const [thumbsOverflow, setThumbsOverflow] = useState(false);
 
   useLayoutEffect(() => {
     function update() {
       const el = mainImageRef.current;
       if (el) {
-        setThumbsMaxHeight(el.clientHeight);
+        const mainH = el.clientHeight;
+        setThumbsMaxHeight(mainH);
         const rect = el.getBoundingClientRect();
         setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
+
+        // measure thumbs overflow synchronously
+        const thumbsEl = thumbsRef.current;
+        if (thumbsEl) {
+          // If thumbnails total height exceeds main image height, enable arrows
+          setThumbsOverflow(thumbsEl.scrollHeight > mainH + 1);
+        } else {
+          setThumbsOverflow(false);
+        }
       } else {
         setThumbsMaxHeight(undefined);
         setMainAspect(undefined);
+        setThumbsOverflow(false);
       }
     }
     update();

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -441,6 +441,12 @@ export default function ProductPage() {
           }),
         }}
       />
+
+      <ContactModal
+        open={contactModalOpen}
+        productName={product.title}
+        onOpenChange={(v) => setContactModalOpen(v)}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -214,8 +214,8 @@ export default function ProductPage() {
             {gallery.length > 0 ? (
               <div className="relative p-0">
                 <div className="grid grid-cols-12 gap-4 items-start">
-                  {/* Thumbnails left (vertical) */}
-                  <div className="col-span-2 relative">
+                  {/* Thumbnails left (vertical) - hidden on mobile */}
+                  <div className="col-span-2 relative hidden lg:block">
                     <div
                       className="overflow-y-auto pr-1 no-scrollbar"
                       ref={(el) => {
@@ -297,8 +297,45 @@ export default function ProductPage() {
                   </div>
 
                   {/* Main image right */}
-                  <div className="col-span-10">
-                    <div className="relative">
+                  <div className="col-span-12 lg:col-span-10">
+                    <div
+                      className="relative"
+                      ref={(el) => {
+                        /* slider ref used for touch */
+                      }}
+                      onPointerDown={(e) => {
+                        const el = e.currentTarget as HTMLDivElement;
+                        (el as any)._startX = e.clientX;
+                        (el as any)._isDown = true;
+                      }}
+                      onPointerMove={(e) => {
+                        const el = e.currentTarget as HTMLDivElement;
+                        if (!(el as any)._isDown) return;
+                        (el as any)._lastX = e.clientX;
+                      }}
+                      onPointerUp={(e) => {
+                        const el = e.currentTarget as HTMLDivElement;
+                        if (!(el as any)._isDown) return;
+                        const startX = (el as any)._startX as number | undefined;
+                        const lastX = (el as any)._lastX as number | undefined;
+                        (el as any)._isDown = false;
+                        if (startX === undefined || lastX === undefined) return;
+                        const dx = lastX - startX;
+                        const threshold = 40;
+                        if (dx < -threshold) {
+                          // swipe left => next
+                          setActiveIndex((s) => (s + 1) % gallery.length);
+                        } else if (dx > threshold) {
+                          // swipe right => prev
+                          setActiveIndex((s) => (s - 1 + gallery.length) % gallery.length);
+                        }
+                      }}
+                    >
+                      {/* Mobile counter */}
+                      <div className="absolute left-3 top-3 rounded-md bg-black/60 text-white text-xs px-2 py-1 lg:hidden">
+                        {displayedIndex + 1} / {gallery.length}
+                      </div>
+
                       {gallery.map((src, i) => (
                         <div
                           key={src + i}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -87,11 +87,19 @@ export default function ProductPage() {
   const mainImageRef = useRef<HTMLDivElement | null>(null);
   const thumbsRef = useRef<HTMLDivElement | null>(null);
   const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(undefined);
+  const [mainAspect, setMainAspect] = useState<string | undefined>(undefined);
 
   useLayoutEffect(() => {
     function update() {
       const el = mainImageRef.current;
-      if (el) setThumbsMaxHeight(el.clientHeight);
+      if (el) {
+        setThumbsMaxHeight(el.clientHeight);
+        const rect = el.getBoundingClientRect();
+        setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
+      } else {
+        setThumbsMaxHeight(undefined);
+        setMainAspect(undefined);
+      }
     }
     update();
     window.addEventListener("resize", update);

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -84,6 +84,20 @@ export default function ProductPage() {
 
   const [activeIndex, setActiveIndex] = useState(0);
 
+  const mainImageRef = useRef<HTMLDivElement | null>(null);
+  const thumbsRef = useRef<HTMLDivElement | null>(null);
+  const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    function update() {
+      const el = mainImageRef.current;
+      if (el) setThumbsMaxHeight(el.clientHeight);
+    }
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [activeIndex, product?.id, gallery.length]);
+
   useEffect(() => setActiveIndex(0), [product?.id]);
 
   if (loading) {

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -303,10 +303,14 @@ export default function ProductPage() {
                       ref={(el) => {
                         /* slider ref used for touch */
                       }}
+                      style={{ touchAction: "pan-y" }}
                       onPointerDown={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
+                        try { el.setPointerCapture(e.pointerId); } catch {}
                         (el as any)._startX = e.clientX;
+                        (el as any)._lastX = e.clientX;
                         (el as any)._isDown = true;
+                        (el as any)._pointerId = e.pointerId;
                       }}
                       onPointerMove={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
@@ -316,19 +320,29 @@ export default function ProductPage() {
                       onPointerUp={(e) => {
                         const el = e.currentTarget as HTMLDivElement;
                         if (!(el as any)._isDown) return;
+                        (el as any)._isDown = false;
+                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
                         const startX = (el as any)._startX as number | undefined;
                         const lastX = (el as any)._lastX as number | undefined;
-                        (el as any)._isDown = false;
                         if (startX === undefined || lastX === undefined) return;
                         const dx = lastX - startX;
                         const threshold = 40;
                         if (dx < -threshold) {
-                          // swipe left => next
                           setActiveIndex((s) => (s + 1) % gallery.length);
                         } else if (dx > threshold) {
-                          // swipe right => prev
                           setActiveIndex((s) => (s - 1 + gallery.length) % gallery.length);
                         }
+                      }}
+                      onPointerCancel={(e) => {
+                        const el = e.currentTarget as HTMLDivElement;
+                        (el as any)._isDown = false;
+                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
+                      }}
+                      onPointerLeave={(e) => {
+                        const el = e.currentTarget as HTMLDivElement;
+                        if (!(el as any)._isDown) return;
+                        (el as any)._isDown = false;
+                        try { if ((el as any)._pointerId !== undefined) el.releasePointerCapture((el as any)._pointerId); } catch {}
                       }}
                     >
                       {/* Mobile counter */}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -107,6 +107,8 @@ export default function ProductPage() {
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const displayedIndex = previewIndex ?? activeIndex;
 
+  const [contactModalOpen, setContactModalOpen] = useState(false);
+
   const mainImageRef = useRef<HTMLDivElement | null>(null);
   const thumbsRef = useRef<HTMLDivElement | null>(null);
   const [thumbsMaxHeight, setThumbsMaxHeight] = useState<number | undefined>(

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -294,7 +294,7 @@ export default function ProductPage() {
               </div>
             ) : (
               <div className="p-0">
-                <div className="w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" style={mainAspect ? { aspectRatio: mainAspect } : undefined} />
+                <div className="w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" style={{ aspectRatio: '1 / 1' }} />
               </div>
             )}
           </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -126,7 +126,7 @@ export default function ProductPage() {
       setMainAspect(`${Math.round(rect.width)} / ${Math.round(rect.height)}`);
 
       const thumbsEl = thumbsRef.current;
-      setThumbsOverflow(thumbsEl ? thumbsEl.scrollHeight > mainH + 1 : false);
+      setThumbsOverflow(thumbsEl ? thumbsEl.scrollHeight > (thumbsEl.clientHeight + 1) : false);
     } else {
       setThumbsMaxHeight(undefined);
       setMainAspect(undefined);

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -363,12 +363,13 @@ export default function ProductPage() {
               <p className="mt-4 text-slate-700">{product.description}</p>
 
               <div className="mt-6 flex gap-6">
-                <Link
-                  to="/contact"
+                <button
+                  type="button"
+                  onClick={() => setContactModalOpen(true)}
                   className="inline-flex items-center rounded-lg bg-[hsl(var(--brand-end))] text-white px-4 py-2.5 text-sm font-semibold shadow"
                 >
                   Request quote
-                </Link>
+                </button>
               </div>
 
               {product.brochures && product.brochures.length > 0 && (

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -247,6 +247,9 @@ export default function ProductPage() {
                         <div
                           key={src + i}
                           id={`slide-${i}`}
+                          ref={(el) => {
+                            if (i === activeIndex) mainImageRef.current = el;
+                          }}
                           className={cn(
                             "aspect-[3/4] w-full max-h-[480px] overflow-hidden rounded-xl bg-slate-50",
                             i === activeIndex ? "block" : "hidden",

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -366,12 +366,6 @@ export default function ProductPage() {
                 >
                   Request quote
                 </Link>
-                <Link
-                  to="/products"
-                  className="text-[hsl(var(--brand-end))] underline underline-offset-4 hover:no-underline text-sm font-semibold"
-                >
-                  Back to Products
-                </Link>
               </div>
 
               {product.brochures && product.brochures.length > 0 && (

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -279,7 +279,7 @@ export default function ProductPage() {
               </div>
             ) : (
               <div className="p-0">
-                <div className="aspect-[3/4] w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
+                <div className="w-full max-h-[480px] overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" style={mainAspect ? { aspectRatio: mainAspect } : undefined} />
               </div>
             )}
           </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -196,11 +196,12 @@ export default function ProductPage() {
                           <button
                             key={src + i}
                             className={cn(
-                              "relative aspect-[3/4] w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
+                              "relative w-full overflow-hidden rounded-md focus:outline-none focus:ring-0 focus-visible:ring-0 focus:border-[hsl(var(--brand-end))]",
                               i === activeIndex
                                 ? "border-2 border-[hsl(var(--brand-end))]"
                                 : "border border-transparent",
                             )}
+                            style={mainAspect ? { aspectRatio: mainAspect } : undefined}
                             onMouseEnter={() => setActiveIndex(i)}
                             onFocus={() => setActiveIndex(i)}
                             onClick={() => setActiveIndex(i)}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -154,7 +154,15 @@ export default function ProductPage() {
     // run once after DOM mutations; images may not be loaded yet
     updateSizes();
     window.addEventListener("resize", updateSizes);
-    return () => window.removeEventListener("resize", updateSizes);
+
+    const thumbsEl = thumbsRef.current;
+    const onThumbsScroll = () => updateThumbsScrollState(thumbsEl);
+    if (thumbsEl) thumbsEl.addEventListener("scroll", onThumbsScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("resize", updateSizes);
+      if (thumbsEl) thumbsEl.removeEventListener("scroll", onThumbsScroll as any);
+    };
   }, [activeIndex, product?.id, gallery.length]);
 
   useEffect(() => setActiveIndex(0), [product?.id]);

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -280,6 +280,7 @@ export default function ProductPage() {
                             alt={`${product.title} image ${i + 1}`}
                             className="h-full w-full object-cover"
                             loading={i === 0 ? "eager" : "lazy"}
+                            onLoad={() => updateSizes()}
                           />
                         </div>
                       ))}

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -288,34 +288,39 @@ export default function ProductPage() {
                     {/* Vertical scroll controls (up/down) */}
                     {thumbsOverflow && (
                       <>
-                        <button
-                          type="button"
-                          className="absolute -top-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
-                          aria-label="Scroll thumbnails up"
-                          onClick={() => {
-                            const el = thumbsRef.current;
-                            const step = Math.round(
-                              (thumbsMaxHeight || 120) * 0.5,
-                            );
-                            el?.scrollBy({ top: -step, behavior: "smooth" });
-                          }}
-                        >
-                          <ArrowUp className="h-4 w-4 mx-auto" />
-                        </button>
-                        <button
-                          type="button"
-                          className="absolute -bottom-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
-                          aria-label="Scroll thumbnails down"
-                          onClick={() => {
-                            const el = thumbsRef.current;
-                            const step = Math.round(
-                              (thumbsMaxHeight || 120) * 0.5,
-                            );
-                            el?.scrollBy({ top: step, behavior: "smooth" });
-                          }}
-                        >
-                          <ArrowDown className="h-4 w-4 mx-auto" />
-                        </button>
+                        {thumbsCanScrollUp && (
+                          <button
+                            type="button"
+                            className="absolute -top-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
+                            aria-label="Scroll thumbnails up"
+                            onClick={() => {
+                              const el = thumbsRef.current;
+                              const step = Math.round(
+                                (thumbsMaxHeight || 120) * 0.5,
+                              );
+                              el?.scrollBy({ top: -step, behavior: "smooth" });
+                            }}
+                          >
+                            <ArrowUp className="h-4 w-4 mx-auto" />
+                          </button>
+                        )}
+
+                        {thumbsCanScrollDown && (
+                          <button
+                            type="button"
+                            className="absolute -bottom-3 left-1/2 -translate-x-1/2 z-10 h-7 w-7 rounded-full bg-white/90 backdrop-blur text-slate-700 hover:bg-white"
+                            aria-label="Scroll thumbnails down"
+                            onClick={() => {
+                              const el = thumbsRef.current;
+                              const step = Math.round(
+                                (thumbsMaxHeight || 120) * 0.5,
+                              );
+                              el?.scrollBy({ top: step, behavior: "smooth" });
+                            }}
+                          >
+                            <ArrowDown className="h-4 w-4 mx-auto" />
+                          </button>
+                        )}
                       </>
                     )}
                   </div>

--- a/public/data/products.json
+++ b/public/data/products.json
@@ -9,7 +9,18 @@
     "images": [
       "/placeholder.svg?img=p-bsc-a2-1",
       "/placeholder.svg?img=p-bsc-a2-2",
-      "/placeholder.svg?img=p-bsc-a2-3"
+      "/placeholder.svg?img=p-bsc-a2-3",
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",,
+      "/placeholder.svg?img=p-bsc-a2-2",
     ],
     "specs": [
       { "name": "Class", "value": "II, Type A2" },

--- a/public/data/products.json
+++ b/public/data/products.json
@@ -10,17 +10,17 @@
       "/placeholder.svg?img=p-bsc-a2-1",
       "/placeholder.svg?img=p-bsc-a2-2",
       "/placeholder.svg?img=p-bsc-a2-3",
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",,
-      "/placeholder.svg?img=p-bsc-a2-2",
+      "/placeholder.svg?img=p-bsc-a2-4",
+      "/placeholder.svg?img=p-bsc-a2-5",
+      "/placeholder.svg?img=p-bsc-a2-6",
+      "/placeholder.svg?img=p-bsc-a2-7",
+      "/placeholder.svg?img=p-bsc-a2-8",
+      "/placeholder.svg?img=p-bsc-a2-9",
+      "/placeholder.svg?img=p-bsc-a2-10",
+      "/placeholder.svg?img=p-bsc-a2-11",
+      "/placeholder.svg?img=p-bsc-a2-12",
+      "/placeholder.svg?img=p-bsc-a2-13",
+      "/placeholder.svg?img=p-bsc-a2-14"
     ],
     "specs": [
       { "name": "Class", "value": "II, Type A2" },
@@ -482,7 +482,7 @@
     ],
     "specs": [
       { "name": "Volume", "value": "2 × 100 L (stacked)" },
-      { "name": "CO₂ Range", "value": "0–20%" },
+      { "name": "CO��� Range", "value": "0–20%" },
       { "name": "Temp Stability", "value": "±0.1°C" }
     ],
     "brochures": [


### PR DESCRIPTION
## Purpose

The user requested to fix the product card image hover functionality. Instead of automatically cycling through images, they wanted the image area to be divided into sections corresponding to the number of photos, with each section showing the appropriate image when hovered. The hover should be a preview only - removing the cursor should return to the main image without making the hovered image active.

## Code changes

- **Product card hover system**: Implemented pointer-based image preview in `ProductCard` component that divides the image area into sections based on the number of images
- **Image gallery improvements**: Enhanced the product detail page gallery with better thumbnail scrolling, aspect ratio handling, and preview functionality
- **CSS enhancements**: Added `.no-scrollbar` utility class to hide native scrollbars when using custom controls, and improved RGBA color formatting consistency
- **Data updates**: Added more sample images to the first product for testing the multi-image hover functionality
- **Error handling**: Improved product data fetching with fallback URL attempts and better error messagesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3fd09cc063d94568a2da7b25c874ef6a/mystic-space)

👀 [Preview Link](https://3fd09cc063d94568a2da7b25c874ef6a-mystic-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3fd09cc063d94568a2da7b25c874ef6a</projectId>-->
<!--<branchName>mystic-space</branchName>-->